### PR TITLE
Add Maven GPG plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.amazonaws:dynamodb-import-export-tool:jar:1.0.1
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-gpg-plugin is missing. @ line 117, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This warning is presented when running `mvn install`.